### PR TITLE
[UI] Alert Component 구현

### DIFF
--- a/src/components/common/Alert/Alert.tsx
+++ b/src/components/common/Alert/Alert.tsx
@@ -1,0 +1,66 @@
+import { designSystem } from "@styles/designSystem";
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { styled } from "styled-components";
+
+type AlertType = {
+  message: string;
+  closeAlertHandler: () => void;
+  buttons: ReactNode[];
+};
+
+export default function Alert({
+  message,
+  closeAlertHandler,
+  buttons,
+}: AlertType) {
+  const modalRef = useRef<HTMLDialogElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    setIsOpen(true);
+
+    const onOutsideClick = (e: MouseEvent) => {
+      if (!modalRef.current?.contains(e.target as Node)) {
+        closeAlertHandler();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener("click", onOutsideClick);
+    }
+
+    return () => {
+      window.removeEventListener("click", onOutsideClick);
+    };
+  }, [isOpen, closeAlertHandler]);
+
+  return (
+    <StyledAlert ref={modalRef}>
+      <span>{message}</span>
+      <ButtonWrapper>{...buttons}</ButtonWrapper>
+    </StyledAlert>
+  );
+}
+
+const StyledAlert = styled.dialog`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 24px 32px;
+  width: 336px;
+  height: 144px;
+  box-sizing: border-box;
+  border: none;
+  border-radius: ${designSystem.radius[16]};
+  box-shadow: 0px 4px 4px 0px #00000040;
+  z-index: 1;
+  font: ${designSystem.font.displayStrong16};
+  color: ${designSystem.color.neutralTextStrong};
+  background-color: ${designSystem.color.neutralBackground};
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 32px;
+  margin-left: auto;
+`;

--- a/src/components/common/Alert/Alert.tsx
+++ b/src/components/common/Alert/Alert.tsx
@@ -1,17 +1,18 @@
 import { designSystem } from "@styles/designSystem";
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { styled } from "styled-components";
+import Button from "../Button";
 
 type AlertType = {
   message: string;
   closeAlertHandler: () => void;
-  buttons: ReactNode[];
+  onDeleteClick: () => void;
 };
 
 export default function Alert({
   message,
   closeAlertHandler,
-  buttons,
+  onDeleteClick,
 }: AlertType) {
   const modalRef = useRef<HTMLDialogElement>(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -34,10 +35,28 @@ export default function Alert({
     };
   }, [isOpen, closeAlertHandler]);
 
+  const deleteHandler = () => {
+    onDeleteClick();
+    closeAlertHandler();
+  };
+
   return (
     <StyledAlert ref={modalRef}>
       <span>{message}</span>
-      <ButtonWrapper>{...buttons}</ButtonWrapper>
+      <ButtonWrapper>
+        <Button
+          color="accentTextWeak"
+          fontName="displayDefault16"
+          value="취소"
+          onClick={closeAlertHandler}
+        />
+        <Button
+          color="systemWarning"
+          fontName="displayStrong16"
+          value="삭제"
+          onClick={deleteHandler}
+        />
+      </ButtonWrapper>
     </StyledAlert>
   );
 }


### PR DESCRIPTION
## Issues
- #7 

## What is this PR? 👓
- Alert Component 구현

## Key changes 🔑
- Alert Component UI 구현
- ref, state를 통해 Alert창 외부 클릭 시 닫기 기능 구현

## To reviewers 👋
- useDropdown 훅을 적용시켜 보려고 했지만 실패했습니다
- 실패하며 기존 Menu 컴포넌트의 문제점 발견했습니다(구두로 공유 예정)
- 사용처에서 state, set함수를 써야하는 불편함이 있습니다

적용 예시
``` typescript
function App() {
  const [isOpenModal, setIsOpenModal] = useState(false);

  const toggleModal = () => {
    setIsOpenModal((prev) => !prev);
  };

  const onDeleteLocation = () => {
    console.log("삭제됐어요!");
  };

  return (
    <ThemeProvider theme={theme}>
      <GlobalStyle />
      <Button onClick={toggleModal} value="알러트" />
      {isOpenModal && (
        <Alert
          message="'역삼1동'을 삭제하시겠어요?"
          closeAlertHandler={toggleModal}
          onDeleteClick={onDeleteLocation}
        />
      )}
    </ThemeProvider>
  );
}
```