### PR TITLE
[Refactor] 버튼 컴포넌트 props, designSystem filter type error 수정

### DIFF
--- a/src/components/Modal/AddressModal/Content/AddressIndicatorList.tsx
+++ b/src/components/Modal/AddressModal/Content/AddressIndicatorList.tsx
@@ -39,7 +39,7 @@ export default function AddressIndicatorList({
           </AddressIndicator>
         ))}
         <Button
-          size={{ width: "288px", height: "56px" }}
+          size={{ width: 288, height: 56 }}
           leftIcon={<PlusIcon />}
           fontName="availableStrong16"
           color="accentTextWeak"

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import styled from "styled-components";
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  size?: { width: string; height: string };
+  size?: { width: number; height: number };
   direction?: "row" | "column";
   radius?: Radius;
   fontName?: FontName;
@@ -67,7 +67,7 @@ const ButtonContent = ({
 };
 
 const StyledButton = styled.button<{
-  $size?: { width: string; height: string };
+  $size?: { width: number; height: number };
   $direction?: "row" | "column";
   $color?: ColorName;
   $backgroundColor?: ColorName;
@@ -81,8 +81,8 @@ const StyledButton = styled.button<{
   gap: 4px;
   cursor: pointer;
 
-  width: ${({ $size }) => $size?.width};
-  height: ${({ $size }) => $size?.height};
+  width: ${({ $size }) => $size?.width + "px"};
+  height: ${({ $size }) => $size?.height + "px"};
   color: ${({ $color, theme: { color } }) => $color && color[$color]};
   flex-direction: ${({ $direction }) => $direction};
   font: ${({ $fontName, theme: { font } }) => $fontName && font[$fontName]};

--- a/src/styles/designSystem.ts
+++ b/src/styles/designSystem.ts
@@ -77,8 +77,25 @@ export const designSystem = {
   filter: {
     neutralTextWeak:
       "opacity(60%) brightness(0) saturate(100%) invert(20%) sepia(2%) saturate(3198%) hue-rotate(202deg) brightness(93%) contrast(83%)",
+    neutralText: "",
+    neutralTextStrong: "",
+    neutralBackground: "",
+    neutralBackgroundWeak: "",
+    neutralBackgroundBold: "",
+    neutralBackgroundBlur: "",
+    neutralBorder: "",
+    neutralBorderStrong: "",
+    neutralOverlay: "",
+
     accentText:
       "invert(100%) sepia(97%) saturate(15%) hue-rotate(110deg) brightness(103%) contrast(102%)",
+    accentTextWeak: "",
+    accentPrimary: "",
+    accentSecondary: "",
+
+    systemWarning: "",
+    systemBackground: "",
+    systemBackgroundWeak: "",
   },
   backdropFilter: {
     blur: "blur(8px)",


### PR DESCRIPTION
## Issues
- #4 

## What is this PR? 👓
- 버튼 컴포넌트 props, designSystem filter type error 수정

## Key changes 🔑
- filter color key 없는 경우 type error 해결
- 버튼 size width, height number만 받도록 변경했습니다.

## To reviewers 👋
- 처음에는 width,height를 px 이외에 rem/em 다른 단위로도 작성할 수 있도록 하려고 했는데, px로만 작성하고 매번 귀찮게 작성하지 않아도 되도록 했어요.
- icon filter가 어차피 color랑 동일하게 주게 돼서 별도의 prop으로 받기 보다는 color로 동일하게 적용하도록 일단 filter 객체에 color와 동일한 key값들 추가해두었어요!