### PR TITLE
tanstack-query key 관리 방식 개선 및 Products 컴포넌트 적용, 기타 타입 개선, 마지막 방문 동네 설정(찐막)

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-ts",
       "version": "0.0.0",
       "dependencies": {
+        "@lukemorales/query-key-factory": "^1.3.2",
         "@tanstack/react-query": "^4.33.0",
         "@tanstack/react-query-devtools": "^4.35.0",
         "axios": "^1.5.0",
@@ -3683,6 +3684,18 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
+    },
+    "node_modules/@lukemorales/query-key-factory": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@lukemorales/query-key-factory/-/query-key-factory-1.3.2.tgz",
+      "integrity": "sha512-SFOWcB5ec+RhlKjLjZxTAbOPF2uXNED6lqXiMu3TUt2twKzxE/QLhnYkdbxOBMK5Wwc2Ia+WP3yqCPRKWywnwQ==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@tanstack/query-core": ">= 4.0.0",
+        "@tanstack/react-query": ">= 4.0.0"
+      }
     },
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
@@ -22815,6 +22828,12 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
+    },
+    "@lukemorales/query-key-factory": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@lukemorales/query-key-factory/-/query-key-factory-1.3.2.tgz",
+      "integrity": "sha512-SFOWcB5ec+RhlKjLjZxTAbOPF2uXNED6lqXiMu3TUt2twKzxE/QLhnYkdbxOBMK5Wwc2Ia+WP3yqCPRKWywnwQ==",
+      "requires": {}
     },
     "@mdx-js/react": {
       "version": "2.3.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -13,6 +13,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@lukemorales/query-key-factory": "^1.3.2",
     "@tanstack/react-query": "^4.33.0",
     "@tanstack/react-query-devtools": "^4.35.0",
     "axios": "^1.5.0",

--- a/fe/src/api/product/index.ts
+++ b/fe/src/api/product/index.ts
@@ -22,7 +22,7 @@ export const getCategories = async () => {
   return data;
 };
 
-export const getProductDetail = async (productId: string) => {
+export const getProductDetail = async (productId: number) => {
   const { data } = await fetcher.get<ProductDetailInfo>(
     `${PRODUCT_API_PATH.products}/${productId}`
   );
@@ -48,7 +48,7 @@ export const patchProduct = async ({
   productId,
   productInfo,
 }: {
-  productId: string | undefined;
+  productId: number;
   productInfo: FormData;
 }) => {
   const config = {
@@ -64,7 +64,7 @@ export const patchProduct = async ({
   );
 };
 
-export const deleteProduct = async (productId: string) => {
+export const deleteProduct = async (productId: number) => {
   return await fetcher.delete(`${PRODUCT_API_PATH.products}/${productId}`);
 };
 
@@ -77,7 +77,7 @@ export const patchProductStatus = async ({
   productId,
   statusId,
 }: {
-  productId: string | undefined;
+  productId: number;
   statusId: number;
 }) => {
   return await fetcher.patch(
@@ -94,9 +94,9 @@ export const getProduct = async ({
   cursor = 0,
   size = 10,
 }: {
-  addressId: number | null;
-  categoryId: number | null;
-  cursor: number | undefined;
+  addressId: number;
+  cursor: number;
+  categoryId?: number;
   size?: number;
 }) => {
   const baseUrl = PRODUCT_API_PATH.products;

--- a/fe/src/api/product/queries.ts
+++ b/fe/src/api/product/queries.ts
@@ -14,10 +14,11 @@ import {
   getStatuses,
   patchProductStatus,
 } from ".";
+import { productKeys } from "./../queryKeys";
 
 export const useAddressesInfiniteQuery = (option?: { size: number }) => {
   return useInfiniteQuery({
-    queryKey: ["addresses"],
+    ...productKeys.addresses,
     queryFn: ({ pageParam }) => getAddresses(pageParam, option?.size),
     getNextPageParam: (lastPage, allPages) =>
       lastPage.hasNext ? allPages.length : undefined,
@@ -26,15 +27,15 @@ export const useAddressesInfiniteQuery = (option?: { size: number }) => {
 
 export const useCategoryQuery = () => {
   return useQuery({
-    queryKey: ["getCategories"],
+    ...productKeys.categories,
     queryFn: getCategories,
     staleTime: Infinity,
   });
 };
 
-export const useProductDetailQuery = (id: string, enabled: boolean) => {
+export const useProductDetailQuery = (id: number, enabled: boolean) => {
   return useQuery({
-    queryKey: ["getProductDetail", id],
+    ...productKeys.detail(id),
     queryFn: () => getProductDetail(id),
     enabled,
     staleTime: Infinity,
@@ -46,9 +47,9 @@ export const useDeleteProductQuery = ({
   onSuccess,
   invalidateQueryKey,
 }: {
-  productId: string;
+  productId: number;
   onSuccess?: () => void;
-  invalidateQueryKey?: string[];
+  invalidateQueryKey?: readonly unknown[];
 }) => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -81,7 +82,7 @@ export const useDeleteProductQuery = ({
 
 export const useProductStatusesQuery = () => {
   return useQuery({
-    queryKey: ["getStatuses"],
+    ...productKeys.statuses,
     queryFn: () => getStatuses(),
     staleTime: Infinity,
   });
@@ -92,7 +93,7 @@ export const useMutateProductStatus = ({
   invalidateQueryKey,
 }: {
   onSettled?: () => void;
-  invalidateQueryKey?: string[];
+  invalidateQueryKey?: readonly unknown[];
 }) => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -104,7 +105,8 @@ export const useMutateProductStatus = ({
         title: "상태 변경 완료",
         message: "상태 변경이 완료되었습니다.",
       });
-      queryClient.invalidateQueries({ queryKey: invalidateQueryKey });
+      invalidateQueryKey &&
+        queryClient.invalidateQueries({ queryKey: invalidateQueryKey });
     },
     onError: () => {
       toast({
@@ -122,12 +124,12 @@ export const useGetProductListInfiniteQuery = ({
   categoryId,
   size,
 }: {
-  addressId: number | null;
-  categoryId: number | null;
+  addressId: number;
+  categoryId?: number;
   size?: number;
 }) => {
   return useInfiniteQuery({
-    queryKey: ["getProduct", addressId, categoryId, size],
+    ...productKeys.products(addressId, categoryId, size),
     queryFn: ({ pageParam }) =>
       getProduct({ addressId, categoryId, cursor: pageParam, size }),
     getNextPageParam: (lastPage) => {

--- a/fe/src/api/queryKeys.ts
+++ b/fe/src/api/queryKeys.ts
@@ -1,0 +1,27 @@
+import { createQueryKeys } from "@lukemorales/query-key-factory";
+
+export const productKeys = createQueryKeys("product", {
+  addresses: { queryKey: ["getAddresses"] },
+  categories: { queryKey: ["getCategories"] },
+  detail: (id: number) => ({ queryKey: ["getProductDetail", id] }),
+  statuses: { queryKey: ["getStatuses"] },
+  products: (addressId?: number, categoryId?: number, size?: number) => ({
+    queryKey: ["getProduct", addressId, categoryId, size],
+  }),
+});
+
+export const userKeys = createQueryKeys("user", {
+  socialLogin: { queryKey: ["socialLogin"] },
+  member: { queryKey: ["getMember"] },
+  memberAddresses: { queryKey: ["getMemberAddresses"] },
+  productLikeStatus: (productId: number) => ({
+    queryKey: ["getProductLikeStatus", productId],
+  }),
+  wishlistCategory: { queryKey: ["getUserWishlistCategory"] },
+  wishlistProduct: (categoryId: number) => ({
+    queryKey: ["getUserWishlistProduct", categoryId],
+  }),
+  salesProduct: (statusId: number) => ({
+    queryKey: ["getUserSalesProduct", statusId],
+  }),
+});

--- a/fe/src/api/user/index.ts
+++ b/fe/src/api/user/index.ts
@@ -62,7 +62,7 @@ export const patchNickname = async (newNickname: string) => {
   return await fetcher.patch(USER_API_PATH.nickname, { newNickname });
 };
 
-export const getProductLikeStatus = async (productId: string) => {
+export const getProductLikeStatus = async (productId: number) => {
   const path = `${USER_API_PATH.wishlist}/${productId}`;
 
   const { data } = await fetcher.get<{ isWished: boolean }>(path);

--- a/fe/src/api/user/queries.ts
+++ b/fe/src/api/user/queries.ts
@@ -15,6 +15,7 @@ import {
   getUserWishlistProduct,
   postProductLike,
 } from ".";
+import { userKeys } from "./../queryKeys";
 
 export const useUserInfoQuery = (
   { enabled }: { enabled: boolean } = { enabled: true }
@@ -22,13 +23,13 @@ export const useUserInfoQuery = (
   return useQueries({
     queries: [
       {
-        queryKey: ["getMember"],
+        ...userKeys.member,
         queryFn: getMember,
         enabled,
         staleTime: Infinity,
       },
       {
-        queryKey: ["getMemberAddresses"],
+        ...userKeys.memberAddresses,
         queryFn: getMemberAddress,
         enabled,
         staleTime: Infinity,
@@ -37,9 +38,9 @@ export const useUserInfoQuery = (
   });
 };
 
-export const useGetProductLikeQuery = (productId: string) => {
+export const useGetProductLikeQuery = (productId: number) => {
   return useQuery({
-    queryKey: ["getProductLikeStatus", productId],
+    ...userKeys.productLikeStatus(productId),
     queryFn: () => getProductLikeStatus(productId),
     staleTime: Infinity,
   });
@@ -49,7 +50,7 @@ export const useMutateProductLike = ({
   productId,
   onError,
 }: {
-  productId: string;
+  productId: number;
   onError: () => void;
 }) => {
   const queryClient = useQueryClient();
@@ -63,9 +64,7 @@ export const useMutateProductLike = ({
         title: "관심 상품 변경 완료",
         message: "관심 상품 변경이 완료되었습니다.",
       });
-      queryClient.invalidateQueries({
-        queryKey: ["getUserWishlistCategory"],
-      });
+      queryClient.invalidateQueries(userKeys.wishlistCategory);
     },
     onError: () => {
       toast({
@@ -77,16 +76,14 @@ export const useMutateProductLike = ({
     },
     // TODO: 개선 필요
     onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["getProductLikeStatus", productId],
-      });
+      queryClient.invalidateQueries(userKeys.productLikeStatus(productId));
     },
   });
 };
 
 export const useUserLikeCategories = () => {
   return useQuery({
-    queryKey: ["getUserWishlistCategory"],
+    ...userKeys.wishlistCategory,
     queryFn: getUserWishlistCategory,
     staleTime: Infinity,
   });
@@ -94,7 +91,7 @@ export const useUserLikeCategories = () => {
 
 export const useUserWishlistInfiniteQuery = (categoryId: number) => {
   return useInfiniteQuery({
-    queryKey: ["getUserWishlistProduct", categoryId],
+    ...userKeys.wishlistProduct(categoryId),
     queryFn: ({ pageParam }) =>
       getUserWishlistProduct({
         categoryId,
@@ -108,7 +105,7 @@ export const useUserWishlistInfiniteQuery = (categoryId: number) => {
 
 export const useUserSalesInfiniteQuery = (statusId: number) => {
   return useInfiniteQuery({
-    queryKey: ["getUserSalesProduct", statusId],
+    ...userKeys.salesProduct(statusId),
     queryFn: ({ pageParam }) =>
       getUserSalesProduct({
         statusId,

--- a/fe/src/components/Modal/ProductStatusModal/ProductStatusContent.tsx
+++ b/fe/src/components/Modal/ProductStatusModal/ProductStatusContent.tsx
@@ -1,4 +1,5 @@
 import { useMutateProductStatus } from "@api/product/queries";
+import { productKeys } from "@api/queryKeys";
 import { Status } from "@api/type";
 import { useParams } from "react-router-dom";
 import { ListItem, ListPanel } from "../Modal.style";
@@ -11,10 +12,11 @@ export default function ProductStatusContent({
   closeHandler: () => void;
 }) {
   const { productId } = useParams();
+  const numberProductId = Number(productId);
 
   const { mutate: mutateProductStatus } = useMutateProductStatus({
     onSettled: closeHandler,
-    invalidateQueryKey: ["getProductDetail", productId!],
+    invalidateQueryKey: productKeys.detail(numberProductId).queryKey,
   });
 
   return (
@@ -24,7 +26,7 @@ export default function ProductStatusContent({
           key={id}
           $active={false}
           onClick={() =>
-            mutateProductStatus({ productId: productId, statusId: id })
+            mutateProductStatus({ productId: numberProductId, statusId: id })
           }>
           <span>{type}</span>
         </ListItem>

--- a/fe/src/components/ProductDetail/Buttons/ProductLikeButton.tsx
+++ b/fe/src/components/ProductDetail/Buttons/ProductLikeButton.tsx
@@ -11,8 +11,10 @@ import { useParams } from "react-router-dom";
 
 export default function ProductLikeButton() {
   const { productId } = useParams();
+  const numberProductId = Number(productId);
+
   const { data: userProductLike, isSuccess: isGetProductLikeSuccess } =
-    useGetProductLikeQuery(productId!);
+    useGetProductLikeQuery(numberProductId);
 
   const initialIsLiked = useMemo(
     () => userProductLike?.isWished,
@@ -24,7 +26,7 @@ export default function ProductLikeButton() {
   const rollbackLike = () => setIsLiked(initialIsLiked);
 
   const { mutate: mutateLike } = useMutateProductLike({
-    productId: productId!,
+    productId: numberProductId,
     onError: rollbackLike,
   });
 

--- a/fe/src/components/ProductList/Products.tsx
+++ b/fe/src/components/ProductList/Products.tsx
@@ -4,8 +4,10 @@ import { styled } from "styled-components";
 
 export default function Products({
   productList,
+  invalidateQueryKey,
 }: {
   productList: ProductItem[][];
+  invalidateQueryKey: readonly unknown[];
 }) {
   return (
     <StyledProductList>
@@ -13,7 +15,7 @@ export default function Products({
         products.map((productItem: ProductItem) => (
           <ProductListItem
             key={productItem.productId}
-            productItem={productItem}
+            {...{ productItem, invalidateQueryKey }}
           />
         ))
       )}

--- a/fe/src/components/ProductListItem.tsx
+++ b/fe/src/components/ProductListItem.tsx
@@ -3,17 +3,21 @@ import { ReactComponent as HeartIcon } from "@assets/icon/heart.svg";
 import { ReactComponent as MessageIcon } from "@assets/icon/message.svg";
 import ProductStatus from "@components/ProductStatus";
 import { ROUTE_PATH } from "@router/constants";
+import { convertPastTimestamp } from "@utils/time";
 import { useNavigate } from "react-router-dom";
 import { useMemberValue } from "store";
 import { styled } from "styled-components";
 import ProductMoreButton from "./ProductMoreButton";
-import { convertPastTimestamp } from "@utils/time";
 
 type ProductListItemProps = {
   productItem: ProductItem;
+  invalidateQueryKey: readonly unknown[];
 };
 
-export default function ProductListItem({ productItem }: ProductListItemProps) {
+export default function ProductListItem({
+  productItem,
+  invalidateQueryKey,
+}: ProductListItemProps) {
   const navigate = useNavigate();
   const { id: memberId } = useMemberValue();
 
@@ -34,8 +38,9 @@ export default function ProductListItem({ productItem }: ProductListItemProps) {
               <TextDefault>{productItem.title}</TextDefault>
               {isSeller && (
                 <ProductMoreButton
-                  productId={productItem.productId + ""}
+                  productId={productItem.productId}
                   currentStatusId={productItem.statusId}
+                  invalidateQueryKey={invalidateQueryKey}
                 />
               )}
             </div>

--- a/fe/src/components/ProductMoreButton.tsx
+++ b/fe/src/components/ProductMoreButton.tsx
@@ -9,24 +9,17 @@ import MenuIndicator from "./common/Menu/MenuIndicator";
 import { MenuItemInfo } from "./common/Menu/type";
 
 type ProductMoreButtonProps = {
-  productId: string;
+  productId: number;
   currentStatusId: number;
+  invalidateQueryKey: readonly unknown[];
 };
 
 export default function ProductMoreButton({
   productId,
   currentStatusId,
+  invalidateQueryKey,
 }: ProductMoreButtonProps) {
   const navigate = useNavigate();
-  const currentPathname = window.location.pathname;
-
-  // TODO: 쿼리키 관리 방식 개선 후 리팩토링
-  const invalidateQueryKey =
-    currentPathname === "/sales"
-      ? ["getUserSalesProduct"]
-      : currentPathname === "/wish"
-      ? ["getUserWishlistProduct"]
-      : ["getProduct"];
 
   const { data: productStatuses, isSuccess } = useProductStatusesQuery();
   const { onDeleteProduct } = useDeleteProductQuery({

--- a/fe/src/pages/Auth.tsx
+++ b/fe/src/pages/Auth.tsx
@@ -1,3 +1,4 @@
+import { userKeys } from "@api/queryKeys";
 import NavigationBar from "@components/NavigationBar";
 import TopBar from "@components/TopBar";
 import { Error, Loading } from "@components/common/Guide";
@@ -16,7 +17,7 @@ export function Auth() {
   const setIsLogin = useSetIsLogin();
 
   const { data, isLoading, isSuccess, isError } = useQuery({
-    queryKey: ["socialLogin"],
+    ...userKeys.socialLogin,
     enabled: !!accessCode && !!provider,
     queryFn: () => postSocialLogin(provider!, accessCode!), // enabled 조건으로 보장 가능
   });

--- a/fe/src/pages/ProductDetail.tsx
+++ b/fe/src/pages/ProductDetail.tsx
@@ -14,12 +14,13 @@ import styled from "styled-components";
 
 export default function ProductDetail() {
   const member = useMemberValue();
-
-  const { productId } = useParams();
   const { scrollY, ref } = useScroll();
 
+  const { productId } = useParams();
+  const numberProductId = Number(productId);
+
   const { data: productDetailInfo, isSuccess: isProductDetailSuccess } =
-    useProductDetailQuery(productId!, !!productId);
+    useProductDetailQuery(numberProductId, !!productId);
 
   const isScroll = !!scrollY && scrollY > 0;
   const isSeller = member.id === productDetailInfo?.product.seller.id;

--- a/fe/src/pages/ProductList.tsx
+++ b/fe/src/pages/ProductList.tsx
@@ -1,4 +1,5 @@
 import { useGetProductListInfiniteQuery } from "@api/product/queries";
+import { productKeys } from "@api/queryKeys";
 import NavigationBar from "@components/NavigationBar";
 import { SubInfo } from "@components/ProductDetail/common.style";
 import ProductListFAB from "@components/ProductList/ProductListFAB";
@@ -21,7 +22,7 @@ export default function ProductList() {
     fetchNextPage,
   } = useGetProductListInfiniteQuery({
     addressId: currentAddressId,
-    categoryId: categoryId,
+    categoryId,
   });
 
   const ref = useIntersect(() => {
@@ -62,6 +63,9 @@ export default function ProductList() {
           ) : (
             <Products
               productList={productList.pages.map((page) => page.products)}
+              invalidateQueryKey={
+                productKeys.products(currentAddressId, categoryId).queryKey
+              }
             />
           )}
         </>

--- a/fe/src/pages/ProductRegister.tsx
+++ b/fe/src/pages/ProductRegister.tsx
@@ -1,5 +1,6 @@
 import { patchProduct, postProduct } from "@api/product/index";
 import { useProductDetailQuery } from "@api/product/queries";
+import { productKeys } from "@api/queryKeys";
 import { AddressInfo } from "@api/type";
 import ProductRegisterAddress from "@components/ProductRegister/ProductRegisterAddress";
 import ProductRegisterCategory from "@components/ProductRegister/ProductRegisterCategory";
@@ -24,14 +25,17 @@ import { styled } from "styled-components";
 
 export default function ProductRegister() {
   const navigate = useNavigate();
-  const { productId } = useParams();
+  const queryClient = useQueryClient();
+
   const addressList = useAddressListValue();
   const currentAddressId = useCurrentAddressIdValue();
+
+  const { productId } = useParams();
+  const numberProductId = Number(productId);
+
   const [selectedAddressId, setSelectedAddressId] = useState<number | null>(
     currentAddressId
   );
-  const queryClient = useQueryClient();
-
   // Todo: 상태 분리하기 & 상태 관리 라이브러리 쓰기
   const [productInfo, setProductInfo] = useState<ProductInfo>({
     images: [],
@@ -47,10 +51,11 @@ export default function ProductRegister() {
   });
 
   const { data, isSuccess, isLoading, isError } = useProductDetailQuery(
-    productId!,
+    Number(productId),
     !!productId
   );
 
+  // TODO: 아래 두 Mutation 세부 구현 숨기기 위해 hook으로 분리하기
   const newProductMutation = useMutation(postProduct);
   const editProductMutation = useMutation(patchProduct);
 
@@ -92,9 +97,7 @@ export default function ProductRegister() {
         navigate(`${ROUTE_PATH.detail}/${res.data.productId}`, {
           state: { prevRoute: ROUTE_PATH.home },
         });
-        queryClient.invalidateQueries({
-          queryKey: ["getProductDetail", productId],
-        });
+        queryClient.invalidateQueries(productKeys.detail(numberProductId));
       },
       onError: () => {
         return (
@@ -129,15 +132,13 @@ export default function ProductRegister() {
     formData.append("price", price);
 
     editProductMutation.mutate(
-      { productId: productId, productInfo: formData },
+      { productId: numberProductId, productInfo: formData },
       {
         onSuccess: () => {
           navigate(`${ROUTE_PATH.detail}/${productId}`, {
             state: { prevRoute: ROUTE_PATH.home },
           });
-          queryClient.invalidateQueries({
-            queryKey: ["getProductDetail", productId],
-          });
+          queryClient.invalidateQueries(productKeys.detail(numberProductId));
         },
         onError: () => {
           return (

--- a/fe/src/pages/ProductRegister.tsx
+++ b/fe/src/pages/ProductRegister.tsx
@@ -51,7 +51,7 @@ export default function ProductRegister() {
   });
 
   const { data, isSuccess, isLoading, isError } = useProductDetailQuery(
-    Number(productId),
+    numberProductId,
     !!productId
   );
 

--- a/fe/src/pages/SalesList.tsx
+++ b/fe/src/pages/SalesList.tsx
@@ -1,4 +1,5 @@
 import { useProductStatusesQuery } from "@api/product/queries";
+import { userKeys } from "@api/queryKeys";
 import { useUserSalesInfiniteQuery } from "@api/user/queries";
 import NavigationBar from "@components/NavigationBar";
 import { SubInfo } from "@components/ProductDetail/common.style";
@@ -59,6 +60,7 @@ export default function SalesList() {
             ) : (
               <Products
                 productList={salesProducts.pages.map((page) => page.products)}
+                invalidateQueryKey={userKeys.salesProduct(activeTabId).queryKey}
               />
             )}
           </>

--- a/fe/src/pages/WishList.tsx
+++ b/fe/src/pages/WishList.tsx
@@ -1,3 +1,4 @@
+import { userKeys } from "@api/queryKeys";
 import {
   useUserLikeCategories,
   useUserWishlistInfiniteQuery,
@@ -84,6 +85,9 @@ export default function WishList() {
             )}
             <Products
               productList={categoryProducts.pages.map((page) => page.products)}
+              invalidateQueryKey={
+                userKeys.wishlistProduct(activeTabId).queryKey
+              }
             />
             <Target ref={targetRef} />
           </PageContent>

--- a/fe/src/router/UserProvider.tsx
+++ b/fe/src/router/UserProvider.tsx
@@ -39,11 +39,21 @@ export default function UserProvider() {
       const userAddressesInfo = memberAddressResult.data;
       setAddresses(userAddressesInfo);
 
-      // 기존 유저인 경우에만 로컬스토리지에 저장된 값이 없으면 첫번째 주소를 기본 주소로 설정
-      const lastVisitedAddressId =
-        localStorage.getItem("currentAddressId") ?? userAddressesInfo[0].id;
-      userAddressesInfo.length &&
-        setCurrentAddressId(Number(lastVisitedAddressId));
+      const isFirstUser = !userAddressesInfo.length;
+
+      // 기존 유저인 경우에만 로컬스토리지에 저장된 값을 확인하여 기본 주소 설정
+      if (isFirstUser) {
+        return;
+      }
+
+      const userAddressIDs = userAddressesInfo.map((address) => address.id);
+      const storageID = localStorage.getItem("currentAddressId");
+
+      const lastVisitedAddressId = userAddressIDs.includes(Number(storageID))
+        ? storageID
+        : userAddressIDs[0];
+
+      setCurrentAddressId(Number(lastVisitedAddressId));
     }
 
     if (memberAddressResult.isError) {

--- a/fe/src/store/index.ts
+++ b/fe/src/store/index.ts
@@ -9,7 +9,7 @@ const isLoginAtom = atom<boolean>(false);
 const memberAtom = atom<Member>({ id: -1, nickname: "", profileImgUrl: "" });
 const addressListAtom = atom<AddressInfo[]>([DEFAULT_ADDRESS]);
 const currentAddressIdAtom = atom<number>(DEFAULT_ADDRESS.id);
-const currentCategoryIdAtom = atom<number | null>(null);
+const currentCategoryIdAtom = atom<number | undefined>(undefined);
 
 const useIsLoginAtom = atom(
   (get) => get(isLoginAtom),
@@ -45,7 +45,7 @@ const useCurrentCategoryIdAtom = atom(
   (get, set, payload: number) => {
     const prevCategoryId = get(currentCategoryIdAtom);
     if (prevCategoryId === payload) {
-      set(currentCategoryIdAtom, null);
+      set(currentCategoryIdAtom, undefined);
       return;
     }
     set(currentCategoryIdAtom, payload);

--- a/fe/yarn.lock
+++ b/fe/yarn.lock
@@ -1567,6 +1567,11 @@
   "resolved" "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz"
   "version" "3.4.0"
 
+"@lukemorales/query-key-factory@^1.3.2":
+  "integrity" "sha512-SFOWcB5ec+RhlKjLjZxTAbOPF2uXNED6lqXiMu3TUt2twKzxE/QLhnYkdbxOBMK5Wwc2Ia+WP3yqCPRKWywnwQ=="
+  "resolved" "https://registry.npmjs.org/@lukemorales/query-key-factory/-/query-key-factory-1.3.2.tgz"
+  "version" "1.3.2"
+
 "@mdx-js/react@^2.1.5":
   "integrity" "sha512-zQH//gdOmuu7nt2oJR29vFhDv88oGPmVw6BggmrHeMI+xgEkp1B2dX9/bMBSYtK0dyLX/aOmesKS09g222K1/g=="
   "resolved" "https://registry.npmjs.org/@mdx-js/react/-/react-2.3.0.tgz"
@@ -2804,7 +2809,7 @@
   dependencies:
     "remove-accents" "0.4.2"
 
-"@tanstack/query-core@4.35.0":
+"@tanstack/query-core@>= 4.0.0", "@tanstack/query-core@4.35.0":
   "integrity" "sha512-4GMcKQuLZQi6RFBiBZNsLhl+hQGYScRZ5ZoVq8QAzfqz9M7vcGin/2YdSESwl7WaV+Qzsb5CZOAbMBes4lNTnA=="
   "resolved" "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.35.0.tgz"
   "version" "4.35.0"
@@ -2818,7 +2823,7 @@
     "superjson" "^1.10.0"
     "use-sync-external-store" "^1.2.0"
 
-"@tanstack/react-query@^4.33.0", "@tanstack/react-query@^4.35.0":
+"@tanstack/react-query@^4.33.0", "@tanstack/react-query@^4.35.0", "@tanstack/react-query@>= 4.0.0":
   "integrity" "sha512-LLYDNnM9ewYHgjm2rzhk4KG/puN2rdoqCUD+N9+V7SwlsYwJk5ypX58rpkoZAhFyZ+KmFUJ7Iv2lIEOoUqydIg=="
   "resolved" "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.35.0.tgz"
   "version" "4.35.0"


### PR DESCRIPTION
## Issues
- #58 

## What is this PR? 👓
- tanstack-query key 관리 방식 개선(@lukemorales/query-key-factory 라이브러리 설치)
- Products 컴포넌트 적용
- 기존 유저인 경우 스토리지 저장된 동네 비교하여 마지막 방문 동네 설정하도록 개선

## To Reviewer
- 일단 동일한 queryKey만 일관성 있게 사용하기 위해 createQueryKeys API로 queryKey만 관리하도록 했어요.
- mutate hook들은 지금처럼 사용하는 ProductMoreButton에 두고, invalidate 해줘야 하는 쿼리를 요청하는 컴포넌트(Products 컴포넌트 생성하는 컴포넌트)와 가까운 위치에서 props로 전달할 수 있도록 했어요. 
  - 호이가 리뷰도 주셨지만 제 생각에도 ProductMoreButton 컴포넌트가 어떤 쿼리키의 쿼리를 갱신해야 하는지 직접 아는게 아니라, 이를 생성하는 부모로부터 전달받도록 하는게 더 적절하다고 판단해서 반영했습니다!
- productId, categoryId 등 id는 서버 상태와 동일한 타입으로 관리하는게 헷갈리지 않을 것 같아서 모두 다시 number 타입으로 변경했어요!
- api 함수에 넘기는 인자 타입도 null이나 undefined로 명시하지 않고 optional로 받고 전반적으로 반영했습니다.