### PR TITLE
5주차 리팩토링

### DIFF
--- a/fe/src/api/user/constants.ts
+++ b/fe/src/api/user/constants.ts
@@ -20,5 +20,3 @@ export const USER_API_PATH = {
 
 export const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${VITE_OAUTH_KAKAO_CLIENT_ID}&redirect_uri=${VITE_APP_API_URL}${ROUTE_PATH.auth.kakao}&response_type=code`;
 export const GITHUB_LOGIN_URL = `https://github.com/login/oauth/authorize?client_id=${VITE_OAUTH_GITHUB_CLIENT_ID}&redirect_uri=${VITE_APP_API_URL}${ROUTE_PATH.auth.github}`;
-
-export const ENTIRE_STATUS_ID = [1, 2, 3];

--- a/fe/src/api/user/index.ts
+++ b/fe/src/api/user/index.ts
@@ -1,6 +1,6 @@
 import { fetcher } from "@api/fetcher";
-import { AddressInfo, Member, ProductList, Tokens } from "@api/type";
-import { ENTIRE_STATUS_ID, USER_API_PATH } from "./constants";
+import { AddressInfo, Member, ProductList, Status, Tokens } from "@api/type";
+import { USER_API_PATH } from "./constants";
 
 export const postSocialLogin = async (
   provider: "kakao" | "github",
@@ -105,17 +105,21 @@ export const getUserWishlistProduct = async ({
 };
 
 export const getUserSalesProduct = async ({
+  statuses,
   statusId,
   page = 0,
   size = 10,
 }: {
+  statuses: Status[];
   statusId: number;
   page: number;
   size: number;
 }) => {
+  const entireStatusId = statuses.map((status) => status.id);
+
   const { data } = await fetcher.get<ProductList>(
     `${USER_API_PATH.sales}?statusId=${
-      statusId ? statusId : ENTIRE_STATUS_ID
+      statusId ? statusId : entireStatusId
     }&page=${page}&size=${size}`
   );
   return data;

--- a/fe/src/api/user/queries.ts
+++ b/fe/src/api/user/queries.ts
@@ -16,6 +16,7 @@ import {
   postProductLike,
 } from ".";
 import { userKeys } from "./../queryKeys";
+import { Status } from "@api/type";
 
 export const useUserInfoQuery = (
   { enabled }: { enabled: boolean } = { enabled: true }
@@ -103,11 +104,15 @@ export const useUserWishlistInfiniteQuery = (categoryId: number) => {
   });
 };
 
-export const useUserSalesInfiniteQuery = (statusId: number) => {
+export const useUserSalesInfiniteQuery = (
+  statuses: Status[],
+  statusId: number
+) => {
   return useInfiniteQuery({
     ...userKeys.salesProduct(statusId),
     queryFn: ({ pageParam }) =>
       getUserSalesProduct({
+        statuses,
         statusId,
         page: pageParam,
         size: 10,

--- a/fe/src/components/ProductListItem.tsx
+++ b/fe/src/components/ProductListItem.tsx
@@ -16,6 +16,7 @@ import {
 } from "@api/product/queries";
 import Alert from "./common/Alert/Alert";
 import { MenuItemInfo } from "./common/Menu/type";
+import { getFormattedAddress } from "@utils/index";
 
 type ProductListItemProps = {
   productItem: ProductItem;
@@ -83,7 +84,9 @@ export default function ProductListItem({
                 )}
               </div>
               <div className="info-middle">
-                <TextWeak>{productItem.addressName}</TextWeak>
+                <TextWeak>
+                  {getFormattedAddress(productItem.addressName)}
+                </TextWeak>
                 <TextWeak>・</TextWeak>
                 <TextWeak>
                   {convertPastTimestamp(productItem.createdTime)}

--- a/fe/src/components/ProductStatus.tsx
+++ b/fe/src/components/ProductStatus.tsx
@@ -1,5 +1,5 @@
 import { useStatusesValue } from "store";
-import { IS_RESERVATION_ID, IS_SELLING_ID } from "store/constants";
+import { RESERVATION_ID, SELLING_ID } from "store/constants";
 import { styled } from "styled-components";
 
 type ProductStatusProps = {
@@ -10,7 +10,7 @@ export default function ProductStatus({ id }: ProductStatusProps) {
   const productStatuses = useStatusesValue();
 
   const statusType = productStatuses?.find((status) => status.id === id)?.type;
-  const isSelling = id === IS_SELLING_ID;
+  const isSelling = id === SELLING_ID;
 
   return (
     <>
@@ -24,7 +24,7 @@ const Status = styled.div<{ $statusId: number }>`
   padding: 3px 6px;
   border-radius: ${({ theme: { radius } }) => radius[8]};
   background-color: ${({ theme: { color }, $statusId }) =>
-    $statusId === IS_RESERVATION_ID
+    $statusId === RESERVATION_ID
       ? color.accentSecondary
       : color.neutralBorderStrong};
   color: ${({ theme: { color } }) => color.accentText};

--- a/fe/src/pages/Category.tsx
+++ b/fe/src/pages/Category.tsx
@@ -4,14 +4,25 @@ import CategoryList from "@components/Category";
 import TopBar from "@components/TopBar";
 import Button from "@components/common/Buttons/Button";
 import { Error, Loading } from "@components/common/Guide";
+import useAnimation from "@hooks/useAnimation";
+import { slide } from "@styles/animate";
 import { Main, StaticPage } from "@styles/common";
+import { delay } from "@utils/index";
+import { AnimatePresence, motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
+import { SLIDE_TIME } from "store/constants";
+import styled from "styled-components";
 
 export default function Category() {
   const navigate = useNavigate();
-  const moveToPreviousPage = () => navigate(-1);
-
+  const { isAnimating, onLeavePage } = useAnimation();
   const { data, isSuccess, isError, isLoading } = useCategoryQuery();
+
+  const moveToPreviousPage = async () => {
+    onLeavePage();
+    await delay(SLIDE_TIME);
+    navigate(-1);
+  };
 
   return (
     <StaticPage>
@@ -29,11 +40,21 @@ export default function Category() {
         }
         isWithBorder={true}
       />
-      {isSuccess && (
-        <Main>
-          <CategoryList categories={data} />
-        </Main>
-      )}
+      <AnimatePresence>
+        {isAnimating && (
+          <SlideAnimate
+            initial="initial"
+            animate="in"
+            exit="out"
+            variants={slide}>
+            {isSuccess && (
+              <Main>
+                <CategoryList categories={data} />
+              </Main>
+            )}
+          </SlideAnimate>
+        )}
+      </AnimatePresence>
       {isLoading && (
         <Loading
           messages={[
@@ -53,3 +74,5 @@ export default function Category() {
     </StaticPage>
   );
 }
+
+const SlideAnimate = styled(motion.div)``;

--- a/fe/src/pages/ProductDetail.tsx
+++ b/fe/src/pages/ProductDetail.tsx
@@ -19,6 +19,7 @@ import { delay } from "@utils/index";
 import { AnimatePresence, motion } from "framer-motion";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useMemberValue } from "store";
+import { SLIDE_TIME } from "store/constants";
 import styled from "styled-components";
 
 export default function ProductDetail() {
@@ -71,13 +72,13 @@ export default function ProductDetail() {
 
   const onClickBack = async () => {
     onLeavePage();
-    await delay(300);
+    await delay(SLIDE_TIME);
     goBack();
   };
 
   const onClickEdit = async () => {
     onLeavePage();
-    await delay(300);
+    await delay(SLIDE_TIME);
     navigate(ROUTE_PATH.edit + `/${productId}`);
   };
 
@@ -107,7 +108,6 @@ export default function ProductDetail() {
         <AnimatePresence>
           {isAnimating && (
             <StyledProductDetail
-              key="product"
               initial="initial"
               animate="in"
               exit="out"

--- a/fe/src/pages/SalesList.tsx
+++ b/fe/src/pages/SalesList.tsx
@@ -21,7 +21,7 @@ export default function SalesList() {
     hasNextPage,
     isFetching,
     fetchNextPage,
-  } = useUserSalesInfiniteQuery(activeTabId);
+  } = useUserSalesInfiniteQuery(productStatuses, activeTabId);
 
   const targetRef = useIntersect(() => {
     if (hasNextPage) {

--- a/fe/src/pages/SalesList.tsx
+++ b/fe/src/pages/SalesList.tsx
@@ -4,7 +4,7 @@ import NavigationBar from "@components/NavigationBar";
 import { SubInfo } from "@components/ProductDetail/common.style";
 import Products from "@components/ProductList/Products";
 import TopBar from "@components/TopBar";
-import { Loading } from "@components/common/Guide";
+import { Error, Loading } from "@components/common/Guide";
 import { TabButtons } from "@components/common/TabButtons";
 import { useIntersect } from "@hooks/useIntersect";
 import { Main, Page, PageContent, Target } from "@styles/common";
@@ -17,7 +17,7 @@ export default function SalesList() {
   const [activeTabId, setActiveTabId] = useState(DEFAULT_TAB.id);
   const {
     data: salesProducts,
-    isSuccess: isSalesProductsSuccess,
+    status,
     hasNextPage,
     isFetching,
     fetchNextPage,
@@ -42,6 +42,22 @@ export default function SalesList() {
         isWithBorder={true}
       />
       <PageContent>
+        {status === "loading" && (
+          <Loading
+            messages={[
+              "상품 목록을 불러오는 중입니다.",
+              "새로고침을 하지 마세요!",
+            ]}
+          />
+        )}
+        {status === "error" && (
+          <Error
+            messages={[
+              "상품 목록을 불러오는데 실패했어요.",
+              "잠시 후 다시 시도해주세요.",
+            ]}
+          />
+        )}
         {!!productStatuses.length && (
           <TabButtons
             activeTabId={activeTabId}
@@ -49,7 +65,7 @@ export default function SalesList() {
             onTabClick={onTabClick}
           />
         )}
-        {isSalesProductsSuccess && (
+        {status === "success" && (
           <>
             {isEmpty ? (
               <>

--- a/fe/src/store/constants.ts
+++ b/fe/src/store/constants.ts
@@ -1,8 +1,8 @@
-export const IS_SELLING_ID = 1;
-export const IS_RESERVATION_ID = 2;
-export const IS_SOLD_OUT_ID = 3;
+export const SELLING_ID = 1;
+export const RESERVATION_ID = 2;
 export const DEFAULT_TAB = { id: 0, name: "전체" };
 export const DEFAULT_ADDRESS = {
   id: 1168064000,
   name: "역삼1동",
 };
+export const SLIDE_TIME = 220;

--- a/fe/src/store/index.ts
+++ b/fe/src/store/index.ts
@@ -57,7 +57,6 @@ const useStatusesAtom = atom(
   (get) => get(statuesAtom),
   (_, set, payload: Status[]) => {
     set(statuesAtom, payload);
-    localStorage.setItem("statuses", JSON.stringify(payload));
   }
 );
 


### PR DESCRIPTION
상품 상태 리스트 중에
저희가 상수로 관리하고 있는 SELLING_ID와 RESERVATION_ID 없이 구현할 방법이 없을지 고민해보겠습니다!

``` javascript
{
  id: 1,
  type: 'selling',
  name: '판매중'
},
{
  id: 2,
  type: 'reservation',
  name: '예약중'
},
{
  id: 3,
  type: 'sold',
  name: '판매완료'
}
```
만약 응답이 이렇게 온다면
이런 식으로 type에 따라서 구분해도 될 것 같습니다